### PR TITLE
Feature/travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,18 +30,27 @@ install:
 before_script:
   - export CC=gcc-8
   - export CXX=g++-8
-
-script:
-  - mkdir build
-  - cd build
-  - cmake .. -DENABLE_CLANG_TIDY=ON
-  - make  
-  - ../bin/tests
-  - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game
-  - make tidy &> output.txt
-  - |
-    if [[ -n $(awk '/^[^[:blank:]]/{p=0} (/ warning:/||/error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt) ]]; then
-        awk  '/^[^[:blank:]]/{p=0} (/ warning:/||/ error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt > output2.txt
-        awk '(/ warning: /||/ error: /){p=!($0 in a);a[$0]}p' output2.txt | grep --color=always -z -E 'warning|error|note|\^'
-        exit -1;
-    fi
+jobs:
+  include:
+    - stage: build
+    name: "Build, test, format"
+    script:
+      - mkdir build
+      - cd build
+      - cmake .. -DENABLE_CLANG_TIDY=ON
+      - make
+      - ../bin/tests
+      - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game
+    name: "Clang tidy"
+    - script:
+      - mkdir build
+      - cd build
+      - cmake .. -DENABLE_CLANG_TIDY=ON
+      - make
+      - make tidy &> output.txt
+      - |
+        if [[ -n $(awk '/^[^[:blank:]]/{p=0} (/ warning:/||/error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt) ]]; then
+            awk  '/^[^[:blank:]]/{p=0} (/ warning:/||/ error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt > output2.txt
+            awk '(/ warning: /||/ error: /){p=!($0 in a);a[$0]}p' output2.txt | grep --color=always -z -E 'warning|error|note|\^'
+            exit -1;
+        fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,14 @@ jobs:
       script:
         - mkdir build
         - cd build
-        - cmake .. -DENABLE_CLANG_TIDY=ON
+        - cmake ..
         - make
         - ../bin/tests
         - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game
     - script:
-        - mkdir build
-        - cd build
+        - mkdir build-tidy
+        - cd build-tidy
         - cmake .. -DENABLE_CLANG_TIDY=ON
-        - make
         - make tidy &> output.txt
         - |
           if [[ -n $(awk '/^[^[:blank:]]/{p=0} (/ warning:/||/error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt) ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       - ../bin/tests
       - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game
     name: "Clang tidy"
-    - script:
+    script:
       - mkdir build
       - cd build
       - cmake .. -DENABLE_CLANG_TIDY=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,15 +36,7 @@ before_script:
 jobs:
   include:
     - stage: build
-      name: "Build, test, format"
-      script:
-        - mkdir build
-        - cd build
-        - cmake ..
-        - make
-        - ../bin/tests
-        - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game
-    - name: "Clang-tidy"
+      name: "Clang-tidy"
       script:
         - mkdir build-tidy
         - cd build-tidy
@@ -56,3 +48,11 @@ jobs:
               awk '(/ warning: /||/ error: /){p=!($0 in a);a[$0]}p' output2.txt | grep --color=always -z -E 'warning|error|note|\^'
               exit -1;
           fi
+    - name: "Build, test, format"
+      script:
+        - mkdir build
+        - cd build
+        - cmake ..
+        - make
+        - ../bin/tests
+        - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ jobs:
         - make
         - ../bin/tests
         - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game
-    - script:
+    - name: "Clang-tidy"
+      script:
         - mkdir build-tidy
         - cd build-tidy
         - cmake .. -DENABLE_CLANG_TIDY=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 compiler: gcc
+cache:
+  - ccache
 
 os: linux
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,27 +30,27 @@ install:
 before_script:
   - export CC=gcc-8
   - export CXX=g++-8
+
 jobs:
   include:
     - stage: build
-    name: "Build, test, format"
-    script:
-      - mkdir build
-      - cd build
-      - cmake .. -DENABLE_CLANG_TIDY=ON
-      - make
-      - ../bin/tests
-      - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game
-    name: "Clang tidy"
-    script:
-      - mkdir build
-      - cd build
-      - cmake .. -DENABLE_CLANG_TIDY=ON
-      - make
-      - make tidy &> output.txt
-      - |
-        if [[ -n $(awk '/^[^[:blank:]]/{p=0} (/ warning:/||/error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt) ]]; then
-            awk  '/^[^[:blank:]]/{p=0} (/ warning:/||/ error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt > output2.txt
-            awk '(/ warning: /||/ error: /){p=!($0 in a);a[$0]}p' output2.txt | grep --color=always -z -E 'warning|error|note|\^'
-            exit -1;
-        fi
+      name: "Build, test, format"
+      script:
+        - mkdir build
+        - cd build
+        - cmake .. -DENABLE_CLANG_TIDY=ON
+        - make
+        - ../bin/tests
+        - ../external/Clang-Format/run-clang-format.py -r --exclude '*/.ccls-cache/*' ../engine ../game
+    - script:
+        - mkdir build
+        - cd build
+        - cmake .. -DENABLE_CLANG_TIDY=ON
+        - make
+        - make tidy &> output.txt
+        - |
+          if [[ -n $(awk '/^[^[:blank:]]/{p=0} (/ warning:/||/error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt) ]]; then
+              awk  '/^[^[:blank:]]/{p=0} (/ warning:/||/ error:/)&&(!/\/include\/SDL/)&&(!/external/){p=1} p' output.txt > output2.txt
+              awk '(/ warning: /||/ error: /){p=!($0 in a);a[$0]}p' output2.txt | grep --color=always -z -E 'warning|error|note|\^'
+              exit -1;
+          fi


### PR DESCRIPTION
This speeds up the travis build by an incredible 2 minutes!
Not really what I had hoped, but it's an improvement I guess.

Enables ccache (not sure if this actually had any effect, but it can't hurt) and runs clang-tidy parallel with the regular build/test/format.